### PR TITLE
refactor: 주문 도메인 테스트 케이스명 변경

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderAppService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderAppService.java
@@ -1,0 +1,27 @@
+package com.loopers.application.order;
+
+import com.loopers.application.order.dto.OrderCreateCommand;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class OrderAppService {
+
+    private final OrderService orderService;
+
+    private final UserService userService;
+
+    @Transactional
+    public Order order(OrderCreateCommand createCommand) {
+        userService.existsById(createCommand.userId());
+
+        Order order = orderService.createOrder(createCommand);
+
+        return order;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCreateCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderCreateCommand.java
@@ -1,0 +1,30 @@
+package com.loopers.application.order.dto;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.dto.OrderCreateInfo;
+import com.loopers.domain.product.dto.command.ProductQuantityCommand;
+
+import java.util.List;
+
+public record OrderCreateCommand(
+    Long userId,
+    String orderer,
+    String deliveryAddress,
+    String contactNumber,
+    List<OrderLineItem> items,
+    Long availablePoints
+) {
+    public Order toEntity() {
+        return Order.create(new OrderCreateInfo(
+            userId,
+            orderer,
+            deliveryAddress,
+            contactNumber
+        ));
+    }
+
+    public List<ProductQuantityCommand> toProductQuantityCommands() {
+        return items.stream()
+                .map(item -> new ProductQuantityCommand(item.productId(), item.quantity())).toList();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderLineItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/dto/OrderLineItem.java
@@ -1,0 +1,6 @@
+package com.loopers.application.order.dto;
+
+public record OrderLineItem(
+    Long productId,
+    Long quantity
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -19,12 +19,12 @@ public class PointFacade {
     private final PointRepository pointRepository;
 
     @Transactional(rollbackFor = Exception.class)
-    public PointInfo charge(String userId, Integer amount) {
+    public PointInfo charge(String userId, Long amount) {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new EntityNotFoundException("[userId = " + userId + "] 를 찾을 수 없습니다."));
 
-        Point point = pointRepository.findByUserId(user.getUserId())
-                .orElse(Point.create(user.getUserId()));
+        Point point = pointRepository.findByUserId(user.getId())
+                .orElse(Point.create(user.getId()));
 
         point.charge(amount);
 
@@ -32,7 +32,10 @@ public class PointFacade {
     }
 
     public PointInfo get(String userId) {
-        Optional<Point> pointOptional = pointRepository.findByUserId(userId);
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("[userId = " + userId + "] 를 찾을 수 없습니다."));
+
+        Optional<Point> pointOptional = pointRepository.findByUserId(user.getId());
         return pointOptional.map(PointInfo::from).orElse(null);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -3,13 +3,13 @@ package com.loopers.application.point;
 import com.loopers.domain.point.Point;
 
 public record PointInfo(Long id,
-                        String userId,
-                        Integer amount) {
+                        Long userId,
+                        Long amount) {
     public static PointInfo from(Point point) {
         return new PointInfo(
             point.getId(),
             point.getUserId(),
-            point.getAmount()
+            point.getBalance()
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductAppService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductAppService.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
-public class ProductService {
+public class ProductAppService {
     private final ProductRepository productRepository;
 
     public ProductInfo getProduct(Long id) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductInfo.java
@@ -5,7 +5,7 @@ import com.loopers.domain.product.Product;
 public record ProductInfo(Long id,
                           String brandName,
                           String productName,
-                          Integer price,
+                          Long price,
                           String mainImageUrl,
                           String description,
                           Integer stockQuantity,
@@ -18,7 +18,7 @@ public record ProductInfo(Long id,
             product.getPrice(),
             product.getMainImageUrl(),
             product.getDescription(),
-            product.getStockQuantity(),
+            product.getProductStock().getQuantity(),
             product.getProductLikeCount().getLikeCount()
         );
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductsInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductsInfo.java
@@ -5,7 +5,7 @@ import com.loopers.domain.product.Product;
 public record ProductsInfo(Long id,
                            String productName,
                            String brandName,
-                           Integer price,
+                           Long price,
                            String mainImageUrl) {
     public static ProductsInfo from(Product product) {
         return new ProductsInfo(

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -2,7 +2,7 @@ package com.loopers.application.user;
 
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Component;
 public class UserFacade {
     private final UserService userService;
 
-    public UserInfo create(UserCreateCommand userCreateCommand) {
-        User user = userService.create(userCreateCommand);
+    public UserInfo create(UserCreateInfo userCreateInfo) {
+        User user = userService.create(userCreateInfo);
         return UserInfo.from(user);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -4,6 +4,7 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.domain.order.dto.OrderCreateInfo;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.loopers.domain.order.OrderStatus.COMPLETED;
 import static com.loopers.domain.order.OrderStatus.CREATED;
 import static com.loopers.support.validation.TextValidator.requireText;
 import static jakarta.persistence.EnumType.STRING;
@@ -24,47 +26,67 @@ import static lombok.AccessLevel.PROTECTED;
 public class Order extends BaseEntity {
     private Long userId;
 
-    private String userName;
+    private String orderer;
 
     private String deliveryAddress;
 
     private String contactNumber;
 
+    @OneToMany(mappedBy = "order")
     private List<OrderItem> orderItems = new ArrayList<>();
+
+    private Long totalAmount;
 
     @Enumerated(STRING)
     private OrderStatus status;
 
-    @Enumerated(STRING)
-    private PaymentStatus paymentStatus;
-
     private Order(OrderCreateInfo createInfo) {
         this.userId = createInfo.userId();
-        this.userName = createInfo.userName();
+        this.orderer = createInfo.orderer();
         this.deliveryAddress = createInfo.deliveryAddress();
         this.contactNumber = createInfo.contactNumber();
-        this.orderItems = createInfo.orderItems();
 
         this.status = CREATED;
     }
 
     public static Order create(OrderCreateInfo createInfo) {
         validateRequiredOrderInfo(createInfo);
-        validateProductExistence(createInfo.orderItems());
-
         return new Order(createInfo);
     }
 
     private static void validateRequiredOrderInfo(OrderCreateInfo createInfo) {
         requireNonNull(createInfo.userId());
-        requireText(createInfo.userName(), "주문자명을 입력해주세요.");
+        requireText(createInfo.orderer(), "주문자명을 입력해주세요.");
         requireText(createInfo.deliveryAddress(), "배송지를 입력해주세요.");
         requireText(createInfo.contactNumber(), "주문자 연락처를 입력해주세요.");
+    }
+
+    public void addOrderItems(List<OrderItem> orderItems) {
+        validateProductExistence(orderItems);
+        for (OrderItem item : orderItems) {
+            item.setOrder(this);
+        }
+        this.orderItems.addAll(orderItems);
     }
 
     private static void validateProductExistence(List<OrderItem> orderItems) {
         if (orderItems == null || orderItems.isEmpty()) {
             throw new IllegalArgumentException("주문 항목이 비어있습니다.");
         }
+    }
+
+    public void complete() {
+        validateCreateStatus();
+        this.status = COMPLETED;
+    }
+
+    private void validateCreateStatus() {
+        if (this.status != CREATED) {
+            throw new IllegalStateException("주문이 생성되지 않았습니다.");
+        }
+    }
+
+    public void setTotalAmount(Long totalAmount) {
+        this.totalAmount = totalAmount;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -2,9 +2,7 @@ package com.loopers.domain.order;
 
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.order.dto.OrderCreateInfo;
-import com.loopers.support.validation.TextValidator;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -12,10 +10,8 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import static com.loopers.domain.order.OrderStatus.CREATED;
-import static com.loopers.domain.order.PaymentStatus.COMPLETE;
 import static com.loopers.support.validation.TextValidator.requireText;
 import static jakarta.persistence.EnumType.STRING;
 import static java.util.Objects.requireNonNull;
@@ -50,7 +46,6 @@ public class Order extends BaseEntity {
         this.orderItems = createInfo.orderItems();
 
         this.status = CREATED;
-        this.paymentStatus = COMPLETE;
     }
 
     public static Order create(OrderCreateInfo createInfo) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCalculator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCalculator.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.order;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class OrderCalculator {
+    public Long calculateTotalAmount(List<OrderItem> orderItems) {
+        if (orderItems == null || orderItems.isEmpty()) {
+            return 0L;
+        }
+
+        return orderItems.stream()
+                .mapToLong(OrderItem::getTotalPrice)
+                .sum();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -8,6 +8,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -17,25 +18,26 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "order_item")
 @Entity
 public class OrderItem extends BaseEntity {
+    @Setter
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "item_id")
+    @JoinColumn(name = "order_id")
     private Order order;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "item_id")
+    @JoinColumn(name = "product_id")
     private Product product;
 
-    private Integer quantity;
-    private Integer price;
+    private Long quantity;
+    private Long totalPrice;
 
-    private OrderItem(Order order, Product product, Integer quantity, Integer price) {
+    private OrderItem(Order order, Product product, Long quantity, Long totalPrice) {
         this.order = order;
         this.product = product;
         this.quantity = quantity;
-        this.price = price;
+        this.totalPrice = totalPrice;
     }
 
-    public static OrderItem create(Order order, Product product, Integer quantity, Integer price) {
-        return new OrderItem(order, product, quantity, price);
+    public static OrderItem create(Order order, Product product, Long quantity, Long totalPrice) {
+        return new OrderItem(order, product, quantity, totalPrice);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.order;
+
+import java.util.List;
+
+public interface OrderItemRepository {
+    List<OrderItem> saveAll(List<OrderItem> orderItems);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItemService.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.order.dto.OrderItemCreateCommand;
+import com.loopers.domain.product.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class OrderItemService {
+    public List<OrderItem> createOrderItems(Order order, List<OrderItemCreateCommand> createCommands) {
+        return createCommands.stream()
+                .map(command -> OrderItem.create(
+                        order,
+                        command.product(),
+                        command.quantity(),
+                        calculateTotalPrice(command.product(), command.quantity())))
+                .toList();
+    }
+
+    private Long calculateTotalPrice(Product product, Long quantity) {
+        return product.getPrice() * quantity;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.order;
+
+public interface OrderRepository {
+    Order save(Order order);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,0 +1,83 @@
+package com.loopers.domain.order;
+
+import com.loopers.application.order.dto.OrderCreateCommand;
+import com.loopers.domain.order.dto.OrderItemCreateCommand;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.ProductStockService;
+import com.loopers.domain.product.dto.command.ProductStocksDeductCommand;
+import com.loopers.domain.product.dto.result.ProductQuantityResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class OrderService {
+
+    private final OrderItemService orderItemService;
+
+    private final OrderCalculator orderCalculator;
+
+    private final ProductService productService;
+
+    private final ProductStockService productStockService;
+
+    private final PointRepository pointRepository;
+
+    private final OrderRepository orderRepository;
+
+    private final OrderItemRepository orderItemRepository;
+
+
+    public Order createOrder(OrderCreateCommand createCommand) {
+        Order saveOrder = orderRepository.save(createCommand.toEntity());
+
+        List<ProductQuantityResult> productItems =
+                productService.getProductWithStocks(createCommand.toProductQuantityCommands());
+
+        List<OrderItem> orderItems = getOrderItems(productItems, saveOrder);
+        saveOrder.addOrderItems(orderItems);
+        orderItemRepository.saveAll(orderItems);
+
+        calculateTotalAmount(orderItems, saveOrder);
+
+        userPoint(createCommand);
+
+        deductStocks(productItems);
+
+        saveOrder.complete();
+
+        return saveOrder;
+    }
+
+    private void deductStocks(List<ProductQuantityResult> productItems) {
+        List<ProductStocksDeductCommand> stocksDeductCommand = productItems.stream()
+                .map(ProductQuantityResult::toProductStocksDeductCommands)
+                .toList();
+        productStockService.deductStocks(stocksDeductCommand);
+    }
+
+    private void userPoint(OrderCreateCommand createCommand) {
+        Point point = pointRepository.findByUserId(createCommand.userId())
+                .orElseThrow(() -> new IllegalStateException("포인트가 부족합니다."));
+        point.use(createCommand.availablePoints());
+    }
+
+    private void calculateTotalAmount(List<OrderItem> orderItems, Order order) {
+        Long totalAmount = orderCalculator.calculateTotalAmount(orderItems);
+        order.setTotalAmount(totalAmount);
+    }
+
+    private List<OrderItem> getOrderItems(List<ProductQuantityResult> productItems, Order order) {
+        List<OrderItemCreateCommand> orderItemCreateCommand = productItems.stream()
+                .map(ProductQuantityResult::toOrderItemCommands)
+                .toList();
+        List<OrderItem> orderItems = orderItemService.createOrderItems(
+                order, orderItemCreateCommand);
+
+        return orderItems;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderStatus.java
@@ -2,8 +2,5 @@ package com.loopers.domain.order;
 
 public enum OrderStatus {
     CREATED,
-    PAID,
-    PREPARING,
-    SHIPPED,
-    DELIVERED
+    COMPLETED
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/dto/OrderCreateInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/dto/OrderCreateInfo.java
@@ -1,13 +1,8 @@
 package com.loopers.domain.order.dto;
 
-import com.loopers.domain.order.OrderItem;
-
-import java.util.List;
-
 public record OrderCreateInfo(
         Long userId,
-        String userName,
+        String orderer,
         String deliveryAddress,
-        String contactNumber,
-        List<OrderItem> orderItems
+        String contactNumber
 ) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/dto/OrderItemCreateCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/dto/OrderItemCreateCommand.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.order.dto;
+
+import com.loopers.domain.product.Product;
+
+public record OrderItemCreateCommand(
+        Product product,
+        Long quantity
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -3,7 +3,6 @@ package com.loopers.domain.point;
 import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,28 +14,42 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 public class Point extends BaseEntity {
 
-    private String userId;
+    private Long userId;
 
-    private Integer amount;
+    private Long balance;
 
-    private Point(String userId) {
+    private Point(Long userId) {
         this.userId = userId;
-        this.amount = 0;
+        this.balance = 0L;
     }
 
-    public static Point create(String userId) {
+    public static Point create(Long userId) {
         return new Point(userId);
     }
 
-    private void validateChargeAmount(Integer amount) {
-        if (amount <= 0) {
-            throw new IllegalArgumentException("0 이하의 포인트는 충전할 수 없습니다.");
+    public void charge(Long amount) {
+        validateChargeAmount(amount);
+        this.balance += amount;
+    }
+
+    private void validateChargeAmount(Long amount) {
+        if (amount < 100) {
+            throw new IllegalArgumentException("100 이상의 포인트를 충전할 수 있습니다.");
         }
     }
 
+    public void use(Long amount) {
+        validateUseAmount(amount);
+        this.balance -= amount;
+    }
 
-    public void charge(Integer amount) {
-        validateChargeAmount(amount);
-        this.amount += amount;
+    private void validateUseAmount(Long amount) {
+        if (amount < 100) {
+            throw new IllegalArgumentException("포인트는 100원 이상 사용할 수 있습니다.");
+        }
+
+        if (this.balance < amount) {
+            throw new IllegalArgumentException("포인트가 부족합니다.");
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -4,5 +4,5 @@ import java.util.Optional;
 
 public interface PointRepository {
     Point save(Point user);
-    Optional<Point> findByUserId(String id);
+    Optional<Point> findByUserId(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -2,15 +2,12 @@ package com.loopers.domain.product;
 
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.brand.Brand;
-import com.loopers.domain.brand.dto.command.BrandCreateCommand;
 import com.loopers.domain.product.dto.command.ProductCreateCommand;
 import com.loopers.domain.productlike.ProductLikeCount;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.ArrayList;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -23,29 +20,38 @@ public class Product extends BaseEntity {
 
     private String name;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "brand_id")
+    private Brand brand;
+
     private String mainImageUrl;
 
     private String description;
 
-    private Integer price;
-
-    private Integer stockQuantity;
-
-    @ManyToOne
-    @JoinColumn(name = "brand_id")
-    private Brand brand;
+    private Long price;
 
     @Setter
-    @OneToOne(mappedBy = "product")
+    @OneToOne(fetch = LAZY, mappedBy = "product")
+    private ProductStock productStock;
+
+    @Setter
+    @OneToOne(fetch = LAZY, mappedBy = "product")
     private ProductLikeCount productLikeCount;
 
     public Product(ProductCreateCommand createCommand) {
+        validatePrice(createCommand);
+
         this.name = createCommand.name();
         this.mainImageUrl = createCommand.mainImageUrl();
         this.description = createCommand.description();
         this.price = createCommand.price();
-        this.stockQuantity = createCommand.stockQuantity();
         this.brand = createCommand.brand();
+    }
+
+    private static void validatePrice(ProductCreateCommand createCommand) {
+        if (createCommand.price() < 0) {
+            throw new IllegalArgumentException("가격을 정확히 입력주세요.");
+        }
     }
 
     public static Product create(ProductCreateCommand createCommand) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface ProductRepository {
     Product save(Product brand);
+
     List<Product> findAll(ProductsCond productsCond);
     Optional<Product> findById(Long id);
+    Optional<List<Product>> findByIds(List<Long> id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.dto.command.ProductQuantityCommand;
+import com.loopers.domain.product.dto.result.ProductQuantityResult;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class ProductService {
+    private final ProductRepository productRepository;
+
+    public List<Product> findProducts(List<Long> ids) {
+        List<Product> products = productRepository.findByIds(ids)
+                .orElse(List.of());
+
+        if (products.size() != ids.size()) {
+            throw new IllegalStateException("존재하지 않는 상품이 있습니다.");
+        }
+
+        return products;
+    }
+
+    private Map<Long, Product> getProductMap(List<Long> productIds) {
+        return findProducts(productIds).stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+    }
+
+    public List<ProductQuantityResult> getProductWithStocks(List<ProductQuantityCommand> command) {
+        List<Long> productIds = command.stream()
+                .map(ProductQuantityCommand::productId).toList();
+
+        Map<Long, Product> productMap = getProductMap(productIds);
+
+        return command.stream()
+                .map(e -> resolveProductWithStock(productMap, e.productId(), e.quantity())).toList();
+    }
+
+    private static ProductQuantityResult resolveProductWithStock(Map<Long, Product> productMap, Long productId, Long quantity) {
+        Product product = productMap.get(productId);
+        if (product == null) {
+            throw new EntityNotFoundException("상품이 존재하지 않습니다.");
+        }
+        return new ProductQuantityResult(product, quantity);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStock.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.product;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "product_stock")
+@Entity
+public class ProductStock {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    private Integer quantity;
+
+//    @Version
+//    private Long version;
+
+    private ProductStock(Product product, Integer quantity) {
+        this.product = product;
+        this.quantity = quantity;
+    }
+
+    public static ProductStock create(Product product, Integer quantity) {
+        return new ProductStock(product, quantity);
+    }
+
+    public void deduct(Long quantity) {
+        if (this.quantity < quantity) {
+            throw new IllegalArgumentException("상품 재고가 부족합니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStockRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStockRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.product;
+
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductStockRepository {
+    ProductStock save(ProductStock brand);
+    Optional<ProductStock> findById(Long id);
+
+    List<ProductStock> findStocks(List<Long> ids);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStockService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductStockService.java
@@ -1,0 +1,40 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.product.dto.command.ProductStocksDeductCommand;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class ProductStockService {
+    private final ProductStockRepository productStockRepository;
+
+    public void deductStocks(List<ProductStocksDeductCommand> stocksDeductCommand) {
+        List<Long> productIds = stocksDeductCommand.stream()
+                .map(e -> e.product().getId()).toList();
+
+        Map<Long, ProductStock> productStockMap = productStockRepository.findStocks(productIds)
+                .stream()
+                .collect(Collectors.toMap(e -> e.getProduct().getId(), Function.identity()));
+
+
+        stocksDeductCommand.forEach(command -> {
+            deductStock(command, productStockMap);
+        });
+    }
+
+    private void deductStock(ProductStocksDeductCommand command, Map<Long, ProductStock> productStockMap) {
+        ProductStock productStock = productStockMap.get(command.product().getId());
+        if (productStock == null) {
+            throw new EntityNotFoundException("상품 재고가 없습니다.");
+        }
+
+        productStock.deduct(command.quantity());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/command/ProductCreateCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/command/ProductCreateCommand.java
@@ -6,7 +6,6 @@ public record ProductCreateCommand(
         String name,
         String mainImageUrl,
         String description,
-        Integer price,
-        Integer stockQuantity,
+        Long price,
         Brand brand
 ) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/command/ProductQuantityCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/command/ProductQuantityCommand.java
@@ -1,0 +1,6 @@
+package com.loopers.domain.product.dto.command;
+
+public record ProductQuantityCommand(
+        Long productId,
+        Long quantity
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/command/ProductStocksDeductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/command/ProductStocksDeductCommand.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.product.dto.command;
+
+import com.loopers.domain.product.Product;
+
+public record ProductStocksDeductCommand(
+        Product product,
+        Long quantity
+) {}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/result/ProductQuantityResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/dto/result/ProductQuantityResult.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.product.dto.result;
+
+import com.loopers.domain.order.dto.OrderItemCreateCommand;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.dto.command.ProductStocksDeductCommand;
+
+public record ProductQuantityResult(
+        Product product,
+        Long quantity
+) {
+    public OrderItemCreateCommand toOrderItemCommands() {
+        return new OrderItemCreateCommand(product, quantity);
+    }
+
+    public ProductStocksDeductCommand toProductStocksDeductCommands() {
+        return new ProductStocksDeductCommand(product, quantity);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -1,11 +1,10 @@
 package com.loopers.domain.user;
 
 import com.loopers.domain.BaseEntity;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.domain.user.type.GenderType;
 import com.loopers.support.converter.DateConverter;
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,28 +31,24 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private GenderType gender;
 
+    @Transient
     private final String VALID_USER_ID_PATTERN = "^[A-Za-z0-9]{1,10}$";
+    @Transient
     private final String VALID_EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$";
 
-    @Builder
-    private User(String userId, String name, String email, String birthDateString) {
-        validateIdFormat(userId);
-        validateEmailFormat(email);
-        LocalDate birthDateTime = convertBirthDateFormat(birthDateString);
+    private User(UserCreateInfo userCreateInfo) {
+        validateIdFormat(userCreateInfo.userId());
+        validateEmailFormat(userCreateInfo.email());
+        LocalDate birthDateTime = convertBirthDateFormat(userCreateInfo.birthDateString());
 
-        this.userId = userId;
-        this.name = name;
-        this.email = email;
+        this.userId = userCreateInfo.userId();
+        this.name = userCreateInfo.name();
+        this.email = userCreateInfo.email();
         this.birthDate = birthDateTime;
     }
 
-    public static User create(UserCreateCommand userCreateCommand) {
-        return User.builder()
-                .userId(userCreateCommand.userId())
-                .name(userCreateCommand.name())
-                .email(userCreateCommand.email())
-                .birthDateString(userCreateCommand.birthDateString())
-                .build();
+    public static User create(UserCreateInfo userCreateInfo) {
+        return new User(userCreateInfo);
     }
 
     private void validateIdFormat(String id) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -1,9 +1,13 @@
 package com.loopers.domain.user;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
     User save(User user);
-    Optional<User> findByUserId(String id);
+    List<User> saveAll(List<User> user);
+
+    Optional<User> findByUserId(String userId);
     boolean existsByUserId(String userId);
+    boolean existsById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -1,6 +1,6 @@
 package com.loopers.domain.user;
 
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,13 +13,20 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional(rollbackFor = Exception.class)
-    public User create(UserCreateCommand userCreateCommand) {
-        User user = User.create(userCreateCommand);
+    public User create(UserCreateInfo userCreateInfo) {
+        User user = User.create(userCreateInfo);
         return userRepository.save(user);
     }
 
     public User get(String userId) {
         return userRepository.findByUserId(userId)
             .orElseThrow(() -> new EntityNotFoundException("[userId = " + userId + "] 를 찾을 수 없습니다."));
+    }
+
+    public void existsById(Long userId) {
+        boolean isExistsUser = userRepository.existsById(userId);
+        if (isExistsUser == false) {
+            throw new IllegalStateException("사용자가 존재하지 않습니다.");
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/dto/command/UserCreateInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/dto/command/UserCreateInfo.java
@@ -3,7 +3,7 @@ package com.loopers.domain.user.dto.command;
 import com.loopers.domain.user.type.GenderType;
 import jakarta.validation.constraints.NotNull;
 
-public record UserCreateCommand(
+public record UserCreateInfo(
     String userId,
     String name,
     String email,

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderItemJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderItemJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.order.jpa;
+
+import com.loopers.domain.order.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemJpaRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderItemRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderItemRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.order.jpa;
+
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class OrderItemRepositoryImpl implements OrderItemRepository {
+    private final OrderItemJpaRepository orderItemJpaRepository;
+
+    @Override
+    public List<OrderItem> saveAll(List<OrderItem> orderItems) {
+        return orderItemJpaRepository.saveAll(orderItems);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.order.jpa;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.point.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/jpa/OrderRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.order.jpa;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.infrastructure.point.jpa.PointJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class OrderRepositoryImpl implements OrderRepository {
+    private final OrderJpaRepository orderJpaRepository;
+
+    @Override
+    public Order save(Order order) {
+        return orderJpaRepository.save(order);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/jpa/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/jpa/PointJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PointJpaRepository extends JpaRepository<Point, Long> {
-    Optional<Point> findByUserId(String userId);
+    Optional<Point> findByUserId(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/jpa/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/jpa/PointRepositoryImpl.java
@@ -18,7 +18,7 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
-    public Optional<Point> findByUserId(String userId) {
+    public Optional<Point> findByUserId(Long userId) {
         return pointJpaRepository.findByUserId(userId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/ProductJpaRepository.java
@@ -3,8 +3,10 @@ package com.loopers.infrastructure.product.jpa;
 import com.loopers.domain.product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
     Optional<Product> findById(Long id);
+    Optional<List<Product>> findByIdIn(List<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/ProductRepositoryImpl.java
@@ -64,4 +64,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public Optional<Product> findById(Long id) {
         return productJpaRepository.findById(id);
     }
+
+    @Override
+    public Optional<List<Product>> findByIds(List<Long> ids) {
+        return productJpaRepository.findByIdIn(ids);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/ProductStockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/ProductStockRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.loopers.infrastructure.product.jpa;
+
+import com.loopers.domain.product.ProductStock;
+import com.loopers.domain.product.ProductStockRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class ProductStockRepositoryImpl implements ProductStockRepository {
+
+    private final StockJpaRepository stockJpaRepository;
+
+    private JPAQueryFactory queryFactory;
+
+    public ProductStockRepositoryImpl(StockJpaRepository stockJpaRepository,
+                                      EntityManager em) {
+        this.stockJpaRepository = stockJpaRepository;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public ProductStock save(ProductStock productStock) {
+        return stockJpaRepository.save(productStock);
+    }
+    @Override
+    public Optional<ProductStock> findById(Long id) {
+        return stockJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<ProductStock> findStocks(List<Long> ids) {
+        return stockJpaRepository.findByIdIn(ids)
+                .orElse(List.of());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/StockJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/jpa/StockJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.product.jpa;
+
+import com.loopers.domain.product.ProductStock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockJpaRepository extends JpaRepository<ProductStock, Long> {
+    Optional<ProductStock> findById(Long id);
+    Optional<List<ProductStock>> findByIdIn(List<Long> ids);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/jpa/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/jpa/UserRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.loopers.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -18,6 +19,11 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
+    public List<User> saveAll(List<User> users) {
+        return userJpaRepository.saveAll(users);
+    }
+
+    @Override
     public Optional<User> findByUserId(String userId) {
         return userJpaRepository.findByUserId(userId);
     }
@@ -25,5 +31,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public boolean existsByUserId(String userId) {
         return userJpaRepository.existsByUserId(userId);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return userJpaRepository.existsById(id);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/brand/BrandV1Controller.java
@@ -2,14 +2,8 @@ package com.loopers.interfaces.api.brand;
 
 import com.loopers.application.brand.BrandFacade;
 import com.loopers.application.brand.BrandInfo;
-import com.loopers.application.user.UserFacade;
-import com.loopers.application.user.UserInfo;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.interfaces.api.user.UserV1ApiSpec;
-import com.loopers.interfaces.api.user.UserV1Dto;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -6,10 +6,10 @@ import jakarta.validation.constraints.NotNull;
 public class PointV1Dto {
     public record ChargeRequest(
         @NotNull(message = "충전할 포인트 금액을 입력해주세요.")
-        Integer amount
+        Long amount
     ) {}
 
-    public record ChargeResponse(Integer amount) {
+    public record ChargeResponse(Long amount) {
         public static ChargeResponse from(PointInfo info) {
             return new ChargeResponse(
                     info.amount()
@@ -17,8 +17,8 @@ public class PointV1Dto {
         }
     }
 
-    public record InfoResponse(String userId,
-                               Integer amount) {
+    public record InfoResponse(Long userId,
+                               Long amount) {
         public static InfoResponse from(PointInfo info) {
             return new InfoResponse(
                     info.userId(),

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -1,6 +1,6 @@
 package com.loopers.interfaces.api.user;
 
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,7 +14,7 @@ public interface UserV1ApiSpec {
     )
     ApiResponse<UserV1Dto.CreateResponse> create(
         @Schema(name = "유저 정보", description = "유저 정보")
-        UserCreateCommand memberCreateRequest
+        UserCreateInfo memberCreateRequest
     );
 
     @Operation(

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -2,7 +2,7 @@ package com.loopers.interfaces.api.user;
 
 import com.loopers.application.user.UserFacade;
 import com.loopers.application.user.UserInfo;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
@@ -18,7 +18,7 @@ public class UserV1Controller implements UserV1ApiSpec {
     @PostMapping("")
     @Override
     public ApiResponse<UserV1Dto.CreateResponse> create(
-            @Valid @RequestBody UserCreateCommand memberCreateRequest) {
+            @Valid @RequestBody UserCreateInfo memberCreateRequest) {
         UserInfo info = userFacade.create(memberCreateRequest);
         UserV1Dto.CreateResponse response = UserV1Dto.CreateResponse.from(info);
         return ApiResponse.success(response);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderAppServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderAppServiceIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.loopers.domain.order;
+
+import com.loopers.application.order.OrderAppService;
+import com.loopers.application.order.dto.OrderCreateCommand;
+import com.loopers.application.order.dto.OrderLineItem;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.user.User;
+import com.loopers.fixture.infra.brand.BrandFixture;
+import com.loopers.fixture.point.PointFixture;
+import com.loopers.fixture.product.ProductWithStockFixture;
+import com.loopers.fixture.user.UserFixture;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class OrderAppServiceIntegrationTest {
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @Autowired
+    private UserFixture userFixture;
+
+    @Autowired
+    private PointFixture pointFixture;
+
+    @Autowired
+    private BrandFixture brandFixture;
+
+    @Autowired
+    private ProductWithStockFixture productWithStockFixture;
+
+    @Autowired
+    private OrderAppService orderAppService;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("주문을 완료할 때, ")
+    @Nested
+    class POST {
+        @DisplayName("현재 보유 포인트가 100원이고 100원의 상품 1개를 구매할 때, 포인트 100원을 사용해 주문 완료된다.")
+        @Test
+        void completeOrderWithFullPoints() {
+            // given
+            User user = userFixture.save();
+
+            Long balance = 100L;
+            pointFixture.save(user.getId(), balance);
+
+            Long productPrice = 100L;
+            Integer stockQuantity = 1;
+            Product saveProduct = productWithStockFixture.save(
+                    brandFixture.save(),
+                    productPrice,
+                    stockQuantity);
+
+            // when
+            Order order = orderAppService.order(new OrderCreateCommand(
+                    user.getId(),
+                    "주문자",
+                    "seoul gangnam",
+                    "010-0000-0000",
+                    List.of(new OrderLineItem(saveProduct.getId(), 1L)),
+                    100L));
+
+            // then
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+            Optional<Point> pointOptional = pointRepository.findByUserId(user.getId());
+            assertThat(pointOptional.isPresent()).isTrue();
+            assertThat(pointOptional.get().getBalance()).isEqualTo(0);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.loopers.domain.order.OrderStatus.CREATED;
-import static com.loopers.domain.order.PaymentStatus.COMPLETE;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -24,9 +22,6 @@ public class OrderTest {
         @DisplayName("주문 상품이 없는 경우 주문 생성이 실패한다.")
         @Test
         void createOrderWithoutProducts() {
-            // arrange
-            List<OrderItem> orderItems = List.of();
-
             // act
             // assert
             assertThatThrownBy(() -> Order.create(new OrderCreateInfo(
@@ -34,7 +29,7 @@ public class OrderTest {
                     "홍길동",
                     "서울시 강남구",
                     "010-1234-5678",
-                    orderItems)))
+                    List.of())))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -88,7 +83,7 @@ public class OrderTest {
             );
         }
 
-        @DisplayName("주문 항목이 비어있지 않은 경우 주문 생성이 되고 결제 완료가 된다.")
+        @DisplayName("주문 항목이 비어있지 않은 경우 주문 생성된다.")
         @MethodSource("validOrderParameters")
         @ParameterizedTest
         void createOrderWithValidParameters(Long userId, String userName, String deliveryAddress, String contactNumber) {
@@ -104,7 +99,6 @@ public class OrderTest {
             // assert
             assertThat(order).isNotNull();
             assertThat(order.getStatus()).isEqualTo(CREATED);
-            assertThat(order.getPaymentStatus()).isEqualTo(COMPLETE);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import static com.loopers.domain.order.OrderStatus.CREATED;
@@ -19,20 +18,6 @@ public class OrderTest {
     @DisplayName("주문을 생성할 때, ")
     @Nested
     class Create {
-        @DisplayName("주문 상품이 없는 경우 주문 생성이 실패한다.")
-        @Test
-        void createOrderWithoutProducts() {
-            // act
-            // assert
-            assertThatThrownBy(() -> Order.create(new OrderCreateInfo(
-                    1L,
-                    "홍길동",
-                    "서울시 강남구",
-                    "010-1234-5678",
-                    List.of())))
-                    .isInstanceOf(IllegalArgumentException.class);
-        }
-
         @DisplayName("주문한 사용자 정보가 누락된 경우 주문 생성이 실패한다.")
         @Test
         void createOrderWithMissingUserInfo() {
@@ -42,8 +27,7 @@ public class OrderTest {
                     null,
                     "홍길동",
                     "서울시 강남구",
-                    "010-1234-5678",
-                    List.of())))
+                    "010-1234-5678")))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -62,17 +46,13 @@ public class OrderTest {
         @MethodSource("invalidOrderParameters")
         @ParameterizedTest
         void createOrderWithMissingUserInfo(Long userId, String userName, String deliveryAddress, String contactNumber) {
-            // arrange
-            List<OrderItem> orderItems = List.of(new OrderItem());
-
             // act
             // assert
             assertThatThrownBy(() -> Order.create(new OrderCreateInfo(
                     userId,
                     userName,
                     deliveryAddress,
-                    contactNumber,
-                    orderItems
+                    contactNumber
             ))).isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -92,8 +72,7 @@ public class OrderTest {
                     userId,
                     userName,
                     deliveryAddress,
-                    contactNumber,
-                    List.of(new OrderItem())
+                    contactNumber
             ));
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -4,7 +4,7 @@ import com.loopers.application.point.PointFacade;
 import com.loopers.application.point.PointInfo;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.utils.DatabaseCleanUp;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.AfterEach;
@@ -47,7 +47,7 @@ class PointServiceIntegrationTest {
         void failsWhenChargingPointsToNonExistentUser() {
             // arrange
             String userId = "user1234";
-            Integer point = 10_000;
+            Long point = 10_000L;
 
             // act
             // assert
@@ -64,16 +64,16 @@ class PointServiceIntegrationTest {
         void returnsUserPointsWhenUserExists() {
             // arrange
             String userId = "user1234";
-            UserCreateCommand userCreateCommand = new UserCreateCommand(
+            UserCreateInfo userCreateInfo = new UserCreateInfo(
                     userId,
                     "park",
                     "user@domain.com",
                     "2000-01-01",
                     MALE);
-            userRepository.save(User.create(userCreateCommand));
+            User saveUser = userRepository.save(User.create(userCreateInfo));
 
-            Point point = Point.create(userId);
-            point.charge(10_000);
+            Point point = Point.create(saveUser.getId());
+            point.charge(10_000L);
             pointRepository.save(point);
 
             // act
@@ -83,7 +83,7 @@ class PointServiceIntegrationTest {
             assertAll(
                 () -> assertThat(pointInfo).isNotNull(),
                 () -> assertThat(pointInfo.id()).isNotNull(),
-                () -> assertThat(pointInfo.userId()).isEqualTo(userCreateCommand.userId()),
+                () -> assertThat(pointInfo.userId()).isEqualTo(userCreateInfo.userId()),
                 () -> assertThat(pointInfo.amount()).isEqualTo(10_000)
             );
         }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointTest.java
@@ -11,12 +11,12 @@ class PointTest {
     @DisplayName("포인트를 충전할 때, ")
     @Nested
     class Create {
-        @ValueSource(ints = {0, -1, -1000})
+        @ValueSource(longs = {99L, -1L, -1000L})
         @ParameterizedTest
-        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
-        void failsWhenChargingWithZeroOrNegativePoints(Integer amount) {
+        @DisplayName("100 미만의 정수로 포인트를 충전 시 실패한다.")
+        void failsWhenChargingWithZeroOrNegativePoints(Long amount) {
             // arrange
-            String userId = "abcd1234";
+            Long userId = 1L;
             Point point = Point.create(userId);
 
             // assert

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductAppServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductAppServiceIntegrationTest.java
@@ -1,6 +1,9 @@
 package com.loopers.domain.product;
 
-import com.loopers.application.product.*;
+import com.loopers.application.product.ProductAppService;
+import com.loopers.application.product.ProductInfo;
+import com.loopers.application.product.ProductsCond;
+import com.loopers.application.product.ProductsInfo;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.brand.dto.command.BrandCreateCommand;
@@ -18,16 +21,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 import static com.loopers.application.product.ProductsSortType.LIKES_DESC;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 @SpringBootTest
-public class ProductServiceIntegrationTest {
+public class ProductAppServiceIntegrationTest {
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
     @Autowired
-    private ProductService productService;
+    private ProductAppService productAppService;
 
     @Autowired
     private ProductRepository productRepository;
@@ -50,7 +53,7 @@ public class ProductServiceIntegrationTest {
         @Test
         void returnsEmptyListIfNoProductsFound() {
             // act
-            List<ProductsInfo> productsInfo = productService.getAll(new ProductsCond());
+            List<ProductsInfo> productsInfo = productAppService.getAll(new ProductsCond());
 
             // assert
             assertThat(productsInfo).isEmpty();
@@ -69,20 +72,18 @@ public class ProductServiceIntegrationTest {
                     "Test Product 1",
                     "http://example.com/product1.png",
                     "This is a test product 1.",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             productRepository.save(Product.create(new ProductCreateCommand(
                     "Test Product 2",
                     "http://example.com/product2.png",
                     "This is a test product 2.",
-                    20_000,
-                    20,
+                    20_000L,
                     saveBrand)));
 
             // act
-            List<ProductsInfo> productsInfo = productService.getAll(new ProductsCond());
+            List<ProductsInfo> productsInfo = productAppService.getAll(new ProductsCond());
 
             // assert
             assertThat(productsInfo).hasSize(2)
@@ -106,8 +107,7 @@ public class ProductServiceIntegrationTest {
                     "Test Product 1",
                     "http://example.com/product1.png",
                     "This is a test product 1.",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             ProductLikeCount productLikeCount1 = ProductLikeCount.create(saveProduct1);
@@ -119,8 +119,7 @@ public class ProductServiceIntegrationTest {
                     "Test Product 2",
                     "http://example.com/product2.png",
                     "This is a test product 2.",
-                    20_000,
-                    20,
+                    20_000L,
                     saveBrand)));
 
             ProductLikeCount productLikeCount2 = ProductLikeCount.create(saveProduct2);
@@ -130,7 +129,7 @@ public class ProductServiceIntegrationTest {
             saveProduct2.setProductLikeCount(saveLikeCount2);
 
             // act
-            List<ProductsInfo> productsInfo = productService.getAll(new ProductsCond(LIKES_DESC));
+            List<ProductsInfo> productsInfo = productAppService.getAll(new ProductsCond(LIKES_DESC));
 
             // assert
             assertThat(productsInfo).hasSize(2)
@@ -154,23 +153,21 @@ public class ProductServiceIntegrationTest {
                     "Test Product 1",
                     "http://example.com/product1.png",
                     "This is a test product 1.",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             productRepository.save(Product.create(new ProductCreateCommand(
                     "Test Product 2",
                     "http://example.com/product2.png",
                     "This is a test product 2.",
-                    20_000,
-                    20,
+                    20_000L,
                     saveBrand)));
 
             String nonExistentBrandName = "notExistBrand";
             ProductsCond productsCond = new ProductsCond(nonExistentBrandName, null);
 
             // act
-            List<ProductsInfo> productsInfo = productService.getAll(productsCond);
+            List<ProductsInfo> productsInfo = productAppService.getAll(productsCond);
 
             // assert
             assertThat(productsInfo).isEmpty();
@@ -183,7 +180,7 @@ public class ProductServiceIntegrationTest {
             Long nonExistId = 999L;
 
             // act
-            ProductInfo productInfo = productService.getProduct(nonExistId);
+            ProductInfo productInfo = productAppService.getProduct(nonExistId);
 
             // assert
             assertThat(productInfo).isNull();
@@ -202,15 +199,14 @@ public class ProductServiceIntegrationTest {
                     "Test Product",
                     "http://example.com/product.png",
                     "This is a test product.",
-                    10_000,
-                    50,
+                    10_000L,
                     saveBrand)));
 
             ProductLikeCount saveLikeCount = productLikeCountRepository.save(ProductLikeCount.create(saveProduct));
             saveProduct.setProductLikeCount(saveLikeCount);
 
             // act
-            ProductInfo productInfo = productService.getProduct(saveProduct.getId());
+            ProductInfo productInfo = productAppService.getProduct(saveProduct.getId());
 
             // assert
             assertThat(productInfo.id()).isNotNull();
@@ -219,7 +215,7 @@ public class ProductServiceIntegrationTest {
             assertThat(productInfo.mainImageUrl()).isEqualTo(saveProduct.getMainImageUrl());
             assertThat(productInfo.description()).isEqualTo(saveProduct.getDescription());
             assertThat(productInfo.price()).isEqualTo(saveProduct.getPrice());
-            assertThat(productInfo.stockQuantity()).isEqualTo(saveProduct.getStockQuantity());
+            assertThat(productInfo.stockQuantity()).isEqualTo(saveProduct.getProductStock().getQuantity());
             assertThat(productInfo.likeCount()).isEqualTo(saveProduct.getProductLikeCount().getLikeCount());
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/productlike/ProductLikeServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/productlike/ProductLikeServiceIntegrationTest.java
@@ -9,11 +9,8 @@ import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.dto.command.ProductCreateCommand;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.utils.DatabaseCleanUp;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.EntityNotFoundException;
-import org.hibernate.AssertionFailure;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 import static com.loopers.domain.user.type.GenderType.MALE;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -78,13 +74,13 @@ class ProductLikeServiceIntegrationTest {
         @Test
         void productNotFound() {
             // arrange
-            UserCreateCommand userCreateCommand = new UserCreateCommand(
+            UserCreateInfo userCreateInfo = new UserCreateInfo(
                     "user1234",
                     "park",
                     "user@domain.com",
                     "2000-01-01",
                     MALE);
-            userRepository.save(User.create(userCreateCommand));
+            userRepository.save(User.create(userCreateInfo));
 
             // act
             assertThatThrownBy(() -> productLikeAppService.likeProduct("user1234", 1L))
@@ -96,7 +92,7 @@ class ProductLikeServiceIntegrationTest {
         @Test
         void createProductLike() {
             // arrange
-            User saveUser = userRepository.save(User.create(new UserCreateCommand(
+            User saveUser = userRepository.save(User.create(new UserCreateInfo(
                     "user1234",
                     "park",
                     "user@domain.com",
@@ -112,8 +108,7 @@ class ProductLikeServiceIntegrationTest {
                     "product1234",
                     "Product Name",
                     "Product Description",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             // act
@@ -137,7 +132,7 @@ class ProductLikeServiceIntegrationTest {
         @Test
         void userCannotLikeProductTwice() {
             // arrange
-            User saveUser = userRepository.save(User.create(new UserCreateCommand(
+            User saveUser = userRepository.save(User.create(new UserCreateInfo(
                     "user1234",
                     "park",
                     "user@domain.com",
@@ -153,8 +148,7 @@ class ProductLikeServiceIntegrationTest {
                     "product1234",
                     "Product Name",
                     "Product Description",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             productLikeRepository.save(ProductLike.create(saveUser, saveProduct));
@@ -184,7 +178,7 @@ class ProductLikeServiceIntegrationTest {
         @Transactional
         void deleteProductLike() {
             // arrange
-            User saveUser = userRepository.save(User.create(new UserCreateCommand(
+            User saveUser = userRepository.save(User.create(new UserCreateInfo(
                     "user1234",
                     "park",
                     "user@domain.com",
@@ -200,8 +194,7 @@ class ProductLikeServiceIntegrationTest {
                     "product1234",
                     "Product Name",
                     "Product Description",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             productLikeRepository.save(ProductLike.create(saveUser, saveProduct));
@@ -230,7 +223,7 @@ class ProductLikeServiceIntegrationTest {
         @Test
         void deleteProductLikeWhenNotLiked() {
             // arrange
-            User saveUser = userRepository.save(User.create(new UserCreateCommand(
+            User saveUser = userRepository.save(User.create(new UserCreateInfo(
                     "user1234",
                     "park",
                     "user@domain.com",
@@ -246,8 +239,7 @@ class ProductLikeServiceIntegrationTest {
                     "product1234",
                     "Product Name",
                     "Product Description",
-                    10_000,
-                    10,
+                    10_000L,
                     saveBrand)));
 
             assertThat(productLikeRepository.hasUserLikedProduct(saveUser.getId(), saveProduct.getId())).isFalse();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/productlike/ProductLikeServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/productlike/ProductLikeServiceTest.java
@@ -5,7 +5,7 @@ import com.loopers.domain.brand.dto.command.BrandCreateCommand;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.dto.command.ProductCreateCommand;
 import com.loopers.domain.user.User;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,13 +35,13 @@ public class ProductLikeServiceTest {
     @DisplayName("특정 사용자는 좋아요를 하지 않은 하나의 상품에 대해 좋아요를 할 수 있다.")
     void userCanLikeProductOnce() {
         // arrange
-        UserCreateCommand userCreateCommand = new UserCreateCommand(
+        UserCreateInfo userCreateInfo = new UserCreateInfo(
                 "user1234",
                 "park",
                 "user@domain.com",
                 "2000-01-01",
                 MALE);
-        User user = User.create(userCreateCommand);
+        User user = User.create(userCreateInfo);
 
         Brand brand = Brand.create(new BrandCreateCommand(
                 "Test Brand",
@@ -52,8 +52,7 @@ public class ProductLikeServiceTest {
                 "Test Product 1",
                 "http://example.com/product1.png",
                 "This is a test product 1.",
-                10_000,
-                10,
+                10_000L,
                 brand));
 
         when(productLikeRepository.hasUserLikedProduct(user.getId(), product.getId())).thenReturn(false);
@@ -79,13 +78,13 @@ public class ProductLikeServiceTest {
     @DisplayName("특정 사용자는 좋아요를 한 하나의 상품에 대해 다시 좋아요를 할 수 없다.")
     void userCannotLikeProductTwice() {
         // arrange
-        UserCreateCommand userCreateCommand = new UserCreateCommand(
+        UserCreateInfo userCreateInfo = new UserCreateInfo(
                 "user1234",
                 "park",
                 "user@domain.com",
                 "2000-01-01",
                 MALE);
-        User user = User.create(userCreateCommand);
+        User user = User.create(userCreateInfo);
 
         Brand brand = Brand.create(new BrandCreateCommand(
                 "Test Brand",
@@ -96,8 +95,7 @@ public class ProductLikeServiceTest {
                 "Test Product 1",
                 "http://example.com/product1.png",
                 "This is a test product 1.",
-                10_000,
-                10,
+                10_000L,
                 brand));
 
         when(productLikeRepository.hasUserLikedProduct(user.getId(), product.getId())).thenReturn(true);
@@ -115,13 +113,13 @@ public class ProductLikeServiceTest {
     @DisplayName("특정 사용자는 좋아요를 한 하나의 상품에 대해 좋아요를 취소할 수 있다.")
     void userCanUnlikeProduct() {
         // arrange
-        UserCreateCommand userCreateCommand = new UserCreateCommand(
+        UserCreateInfo userCreateInfo = new UserCreateInfo(
                 "user1234",
                 "park",
                 "user@domain.com",
                 "2000-01-01",
                 MALE);
-        User user = User.create(userCreateCommand);
+        User user = User.create(userCreateInfo);
 
         Brand brand = Brand.create(new BrandCreateCommand(
                 "Test Brand",
@@ -132,8 +130,7 @@ public class ProductLikeServiceTest {
                 "Test Product 1",
                 "http://example.com/product1.png",
                 "This is a test product 1.",
-                10_000,
-                10,
+                10_000L,
                 brand));
 
         // arrange
@@ -158,13 +155,13 @@ public class ProductLikeServiceTest {
     @DisplayName("특정 사용자는 좋아요를 취소하지 않은 하나의 상품에 대해 좋아요를 취소할 수 없다.")
     void userCannotUnlikeProductIfNotLiked() {
         // arrange
-        UserCreateCommand userCreateCommand = new UserCreateCommand(
+        UserCreateInfo userCreateInfo = new UserCreateInfo(
                 "user1234",
                 "park",
                 "user@domain.com",
                 "2000-01-01",
                 MALE);
-        User user = User.create(userCreateCommand);
+        User user = User.create(userCreateInfo);
 
         Brand brand = Brand.create(new BrandCreateCommand(
                 "Test Brand",
@@ -175,8 +172,7 @@ public class ProductLikeServiceTest {
                 "Test Product 1",
                 "http://example.com/product1.png",
                 "This is a test product 1.",
-                10_000,
-                10,
+                10_000L,
                 brand));
 
         ProductLikeCount spyProductLikeCount = spy(ProductLikeCount.class);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -2,7 +2,7 @@ package com.loopers.domain.user;
 
 import com.loopers.application.user.UserFacade;
 import com.loopers.application.user.UserInfo;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.domain.user.type.GenderType;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
@@ -52,18 +52,18 @@ class UserServiceIntegrationTest {
             String email = "user@domain.com";
             String birthDateString = "2000-01-01";
             GenderType gender = MALE;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
 
             // act
-            UserInfo userInfo = userFacade.create(userCreateCommand);
+            UserInfo userInfo = userFacade.create(userCreateInfo);
 
             // assert
             assertAll(
                 () -> assertThat(userInfo).isNotNull(),
                 () -> assertThat(userInfo.id()).isNotNull(),
-                () -> assertThat(userInfo.userId()).isEqualTo(userCreateCommand.userId()),
-                () -> assertThat(userInfo.name()).isEqualTo(userCreateCommand.name()),
-                () -> assertThat(userInfo.email()).isEqualTo(userCreateCommand.email()),
+                () -> assertThat(userInfo.userId()).isEqualTo(userCreateInfo.userId()),
+                () -> assertThat(userInfo.name()).isEqualTo(userCreateInfo.name()),
+                () -> assertThat(userInfo.email()).isEqualTo(userCreateInfo.email()),
                 () -> assertThat(userInfo.birthDate()).isEqualTo(LocalDate.of(2000, 1, 1))
             );
 
@@ -79,12 +79,12 @@ class UserServiceIntegrationTest {
             String email = "user@domain.com";
             String birthDateString = "2000-01-01";
             GenderType gender = MALE;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
-            userFacade.create(userCreateCommand);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
+            userFacade.create(userCreateInfo);
 
             // act
             // assert
-            assertThatThrownBy(() -> userFacade.create(userCreateCommand))
+            assertThatThrownBy(() -> userFacade.create(userCreateInfo))
                     .isInstanceOf(Exception.class); // exception 뭘로 만들 지 고민해보기
         }
     }
@@ -97,13 +97,13 @@ class UserServiceIntegrationTest {
         void returnsUserInfoWhenUserExists() {
             // arrange
             String userId = "user1234";
-            UserCreateCommand userCreateCommand = new UserCreateCommand(
+            UserCreateInfo userCreateInfo = new UserCreateInfo(
                     userId,
                     "park",
                     "user@domain.com",
                     "2000-01-01",
                     MALE);
-            userRepository.save(User.create(userCreateCommand));
+            userRepository.save(User.create(userCreateInfo));
 
             // act
             UserInfo userInfo = userFacade.get(userId);
@@ -112,9 +112,9 @@ class UserServiceIntegrationTest {
             assertAll(
                     () -> assertThat(userInfo).isNotNull(),
                     () -> assertThat(userInfo.id()).isNotNull(),
-                    () -> assertThat(userInfo.userId()).isEqualTo(userCreateCommand.userId()),
-                    () -> assertThat(userInfo.name()).isEqualTo(userCreateCommand.name()),
-                    () -> assertThat(userInfo.email()).isEqualTo(userCreateCommand.email()),
+                    () -> assertThat(userInfo.userId()).isEqualTo(userCreateInfo.userId()),
+                    () -> assertThat(userInfo.name()).isEqualTo(userCreateInfo.name()),
+                    () -> assertThat(userInfo.email()).isEqualTo(userCreateInfo.email()),
                     () -> assertThat(userInfo.birthDate()).isEqualTo(LocalDate.of(2000, 1, 1))
             );
         }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserTest.java
@@ -1,6 +1,6 @@
 package com.loopers.domain.user;
 
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.domain.user.type.GenderType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,10 +29,10 @@ class UserTest {
             String email = "abc@abc.com";
             String birthDateString = "2000-01-01";
             GenderType gender = MALE;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
 
             // assert
-            assertThatThrownBy(() -> User.create(userCreateCommand))
+            assertThatThrownBy(() -> User.create(userCreateInfo))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -53,10 +53,10 @@ class UserTest {
             String userId = "user1234";
             String birthDateString = "2000-01-01";
             GenderType gender = MALE;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
 
             // assert
-            assertThatThrownBy(() -> User.create(userCreateCommand))
+            assertThatThrownBy(() -> User.create(userCreateInfo))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -79,10 +79,10 @@ class UserTest {
             String email = "user@abc.com";
             String userId = "user1234";
             GenderType gender = MALE;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
 
             // assert
-            assertThatThrownBy(() -> User.create(userCreateCommand))
+            assertThatThrownBy(() -> User.create(userCreateInfo))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/infra/brand/BrandFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/infra/brand/BrandFixture.java
@@ -1,0 +1,7 @@
+package com.loopers.fixture.infra.brand;
+
+import com.loopers.domain.brand.Brand;
+
+public interface BrandFixture {
+    Brand save();
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/BrandFixtureMonkey.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/BrandFixtureMonkey.java
@@ -1,0 +1,33 @@
+package com.loopers.fixture.infra.fixturemonkey;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import com.loopers.fixture.infra.brand.BrandFixture;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class BrandFixtureMonkey implements BrandFixture {
+    @Autowired
+    private BrandRepository brandRepository;
+
+    private List<Brand> create(int count) {
+        return FixtureMonkeyFactory.create().giveMeBuilder(Brand.class)
+                .set("id", 0L)
+                .sampleList(count);
+    }
+
+    private Brand create() {
+        return Objects.requireNonNull(create(1)).get(0);
+    }
+
+    @Override
+    public Brand save() {
+        Brand brand = create();
+        return brandRepository.save(brand);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/FixtureMonkeyFactory.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/FixtureMonkeyFactory.java
@@ -1,0 +1,13 @@
+package com.loopers.fixture.infra.fixturemonkey;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+
+public class FixtureMonkeyFactory {
+    public static FixtureMonkey create() {
+        return FixtureMonkey.builder()
+                .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+                .defaultNotNull(true)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/PointFixtureMonkey.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/PointFixtureMonkey.java
@@ -1,0 +1,34 @@
+package com.loopers.fixture.infra.fixturemonkey;
+
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.fixture.point.PointFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class PointFixtureMonkey implements PointFixture {
+    @Autowired
+    private PointRepository pointRepository;
+
+    private List<Point> create(Long userId, Long balance, int count) {
+        return FixtureMonkeyFactory.create().giveMeBuilder(Point.class)
+                .set("id", 0L)
+                .set("userId", userId)
+                .set("balance", balance)
+                .sampleList(count);
+    }
+
+    private Point create(Long userId, Long balance) {
+        return Objects.requireNonNull(create(userId, balance, 1)).get(0);
+    }
+
+    @Override
+    public Point save(Long userId, Long balance) {
+        Point point = create(userId, balance);
+        return pointRepository.save(point);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/ProductFixtureMonkey.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/ProductFixtureMonkey.java
@@ -1,0 +1,45 @@
+package com.loopers.fixture.infra.fixturemonkey;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductStock;
+import com.loopers.domain.product.ProductStockRepository;
+import com.loopers.fixture.product.ProductWithStockFixture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class ProductFixtureMonkey implements ProductWithStockFixture {
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductStockRepository productStockRepository;
+
+    private List<Product> createProduct(Brand brand, Long productPrice, int count) {
+        return FixtureMonkeyFactory.create().giveMeBuilder(Product.class)
+                .set("brand", brand)
+                .set("price", productPrice)
+                .set("id", 0L)
+                .set("productStock", ProductStock.create(null, 1))
+                .sampleList(count);
+    }
+
+    private Product createProduct(Brand brand, Long productPrice) {
+        return Objects.requireNonNull(createProduct(brand, productPrice, 1)).get(0);
+    }
+
+    @Transactional
+    @Override
+    public Product save(Brand brand, Long productPrice, Integer stockQuantity) {
+        Product saveProduct = productRepository.save(createProduct(brand, productPrice));
+        ProductStock saveProductStock = productStockRepository.save(ProductStock.create(saveProduct, stockQuantity));
+        saveProduct.setProductStock(saveProductStock);
+        return saveProduct;
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/UserFixtureMonkey.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/infra/fixturemonkey/UserFixtureMonkey.java
@@ -1,0 +1,41 @@
+package com.loopers.fixture.infra.fixturemonkey;
+
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.fixture.user.UserFixture;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+public class UserFixtureMonkey implements UserFixture {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public List<User> create(int count) {
+        return FixtureMonkeyFactory.create().giveMeBuilder(User.class)
+                .set("id", 0L)
+                .sampleList(count);
+    }
+
+    @Override
+    public User create() {
+        return Objects.requireNonNull(create(1)).get(0);
+    }
+
+    @Override
+    public User save() {
+        return userRepository.save(create());
+    }
+
+    @Override
+    public List<User> save(int count) {
+        List<User> users = create(count);
+        return userRepository.saveAll(users);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/point/PointFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/point/PointFixture.java
@@ -1,0 +1,7 @@
+package com.loopers.fixture.point;
+
+import com.loopers.domain.point.Point;
+
+public interface PointFixture {
+    Point save(Long userId, Long balance);
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/product/ProductWithStockFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/product/ProductWithStockFixture.java
@@ -1,0 +1,8 @@
+package com.loopers.fixture.product;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.product.Product;
+
+public interface ProductWithStockFixture {
+    Product save(Brand brand, Long productPrice, Integer stockQuantity);
+}

--- a/apps/commerce-api/src/test/java/com/loopers/fixture/user/UserFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/fixture/user/UserFixture.java
@@ -1,0 +1,12 @@
+package com.loopers.fixture.user;
+
+import com.loopers.domain.user.User;
+
+import java.util.List;
+
+public interface UserFixture {
+    User create();
+    List<User> create(int count);
+    User save();
+    List<User> save(int count);
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/brand/BrandV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/brand/BrandV1ApiE2ETest.java
@@ -5,7 +5,7 @@ import com.loopers.domain.brand.dto.command.BrandCreateCommand;
 import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.point.PointV1Dto;
 import com.loopers.utils.DatabaseCleanUp;
@@ -61,13 +61,13 @@ class BrandV1ApiE2ETest {
         void returnsBrandInfoOnSuccessfulRetrievalOfBrandInfo() {
             // arrange
             String userId = "user1234";
-            UserCreateCommand userCreateCommand = new UserCreateCommand(
+            UserCreateInfo userCreateInfo = new UserCreateInfo(
                     userId,
                     "park",
                     "user@domain.com",
                     "2000-01-01",
                     MALE);
-            userRepository.save(User.create(userCreateCommand));
+            userRepository.save(User.create(userCreateInfo));
 
             String brandName = "Test Brand";
             String logoUrl = "http://example.com/logo.png";
@@ -103,13 +103,13 @@ class BrandV1ApiE2ETest {
         void returnsNotFoundResponseWhenIdDoesNotExist() {
             // arrange
             String userId = "user1234";
-            UserCreateCommand userCreateCommand = new UserCreateCommand(
+            UserCreateInfo userCreateInfo = new UserCreateInfo(
                     userId,
                     "park",
                     "user@domain.com",
                     "2000-01-01",
                     MALE);
-            userRepository.save(User.create(userCreateCommand));
+            userRepository.save(User.create(userCreateInfo));
 
             Long brandId = 999L;
 

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -2,7 +2,7 @@ package com.loopers.interfaces.api.user;
 
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
-import com.loopers.domain.user.dto.command.UserCreateCommand;
+import com.loopers.domain.user.dto.command.UserCreateInfo;
 import com.loopers.domain.user.type.GenderType;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.utils.DatabaseCleanUp;
@@ -61,14 +61,14 @@ class UserV1ApiE2ETest {
             String email = "user@domain.com";
             String birthDateString = "2000-01-01";
             GenderType gender = MALE;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
 
             String requestUrl = ENDPOINT_CREATE;
 
             // act
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
-            HttpEntity<UserCreateCommand> requestEntity = new HttpEntity<>(userCreateCommand, headers);
+            HttpEntity<UserCreateInfo> requestEntity = new HttpEntity<>(userCreateInfo, headers);
 
             ParameterizedTypeReference<ApiResponse<UserV1Dto.CreateResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.CreateResponse>> response =
@@ -77,9 +77,9 @@ class UserV1ApiE2ETest {
             // assert
             assertAll(
                 () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
-                () -> assertThat(response.getBody().data().userId()).isEqualTo(userCreateCommand.userId()),
-                () -> assertThat(response.getBody().data().name()).isEqualTo(userCreateCommand.name()),
-                () -> assertThat(response.getBody().data().email()).isEqualTo(userCreateCommand.email()),
+                () -> assertThat(response.getBody().data().userId()).isEqualTo(userCreateInfo.userId()),
+                () -> assertThat(response.getBody().data().name()).isEqualTo(userCreateInfo.name()),
+                () -> assertThat(response.getBody().data().email()).isEqualTo(userCreateInfo.email()),
                 () -> assertThat(response.getBody().data().birthDate()).isEqualTo(LocalDate.of(2000, 1, 1))
             );
         }
@@ -93,14 +93,14 @@ class UserV1ApiE2ETest {
             String email = "user@domain.com";
             String birthDateString = "2000-01-01";
             GenderType gender = null;
-            UserCreateCommand userCreateCommand = new UserCreateCommand(userId, name, email, birthDateString, gender);
+            UserCreateInfo userCreateInfo = new UserCreateInfo(userId, name, email, birthDateString, gender);
 
             String requestUrl = ENDPOINT_CREATE;
 
             // act
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
-            HttpEntity<UserCreateCommand> requestEntity = new HttpEntity<>(userCreateCommand, headers);
+            HttpEntity<UserCreateInfo> requestEntity = new HttpEntity<>(userCreateInfo, headers);
 
             ParameterizedTypeReference<ApiResponse<UserV1Dto.CreateResponse>> responseType = new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.CreateResponse>> response =
@@ -119,13 +119,13 @@ class UserV1ApiE2ETest {
         void returnsUserInfoOnSuccessfulRetrievalOfMyInfo() {
             // arrange
             String userId = "user1234";
-            UserCreateCommand userCreateCommand = new UserCreateCommand(
+            UserCreateInfo userCreateInfo = new UserCreateInfo(
                     userId,
                     "park",
                     "user@domain.com",
                     "2000-01-01",
                     MALE);
-            userRepository.save(User.create(userCreateCommand));
+            userRepository.save(User.create(userCreateInfo));
 
             String requestUrl = ENDPOINT_GET.apply(userId);
 
@@ -137,9 +137,9 @@ class UserV1ApiE2ETest {
             // assert
             assertAll(
                     () -> assertTrue(response.getStatusCode().is2xxSuccessful()),
-                    () -> assertThat(response.getBody().data().userId()).isEqualTo(userCreateCommand.userId()),
-                    () -> assertThat(response.getBody().data().name()).isEqualTo(userCreateCommand.name()),
-                    () -> assertThat(response.getBody().data().email()).isEqualTo(userCreateCommand.email()),
+                    () -> assertThat(response.getBody().data().userId()).isEqualTo(userCreateInfo.userId()),
+                    () -> assertThat(response.getBody().data().name()).isEqualTo(userCreateInfo.name()),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(userCreateInfo.email()),
                     () -> assertThat(response.getBody().data().birthDate()).isEqualTo(LocalDate.of(2000, 1, 1))
             );
         }

--- a/apps/commerce-api/src/test/java/com/loopers/support/fixture/UserFixture.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/fixture/UserFixture.java
@@ -1,0 +1,9 @@
+package com.loopers.support.fixture;
+
+import com.loopers.domain.user.User;
+
+public class UserFixture {
+    public static User createUser() {
+        return null;
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,8 @@ subprojects {
         testImplementation("org.springframework.boot:spring-boot-testcontainers")
         testImplementation("org.testcontainers:testcontainers")
         testImplementation("org.testcontainers:junit-jupiter")
+        // fixture-monkey
+        testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.1.14")
     }
 
     tasks.withType(Jar::class) { enabled = true }


### PR DESCRIPTION
## 📌 Summary

- 쿠폰 기능 추가
- 주문 시 쿠폰 사용 기능 추가

- 주문 재고, 좋아요, 쿠폰 사용 동시성 테스트 완료

## 💬 Review Points

Q1. 재고 차감을 할 때 네임드 락으로도 해결(부모 트랜잭션에서 lock, unlock, 비즈니스 로직은 하위 트랜잭션)할 수 있다고 생각하는데 문제점(요청마다 DB Connection 2번 연결)이 있어서 네임드 락은 과제에서 제외를 시키신건지 궁금합니다! 실무에서 네임드락은 어떤 상황에 사용하셨는지 궁금합니다!



## ✅ Checklist

### 🗞️ Coupon 도메인

- ✅ 쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- ✅  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- ✅  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- ✅  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- ✅  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- ✅  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- ✅  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- ✅  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- ✅  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- ✅  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- ✅  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- ✅  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- ✅  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.

## 📎 References

