### PR TITLE
refactor: 주문 컨슈머 비즈니스 로직 service로 책임 전가

### DIFF
--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/application/OrderService.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/application/OrderService.kt
@@ -1,0 +1,54 @@
+package com.loopers.domain.order.application
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.loopers.domain.order.dto.OrderCompletedMessage
+import com.loopers.domain.order.dto.OrderMessageEnvelope
+import com.loopers.domain.product.ProductMetrics
+import com.loopers.domain.product.ProductMetricsRepository
+import jakarta.transaction.Transactional
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class OrderService(
+    val productMetricsRepository: ProductMetricsRepository,
+    val jacksonObjectMapper: ObjectMapper,
+    val redisTemplate: RedisTemplate<String, String>,
+) {
+    @Transactional
+    fun processOrderEvent(envelope: OrderMessageEnvelope) {
+        saveMetric(envelope.payload)
+        saveRanking()
+    }
+
+    fun saveMetric(
+        payload: JsonNode
+    ) {
+        var metrics: ProductMetrics? = null
+        val payload = jacksonObjectMapper.treeToValue(payload, OrderCompletedMessage::class.java)
+        for (item in payload.orderItems) {
+            metrics = productMetricsRepository.findByProductId(item.productId)
+                ?: ProductMetrics(productId = item.productId)
+            metrics.soldCount(item.quantity)
+        }
+
+        metrics?.let { productMetricsRepository.save(it) }
+    }
+
+    fun addScoresBatch(entries: Map<String, Double>) {
+        val dateKey = "ranking:order:${LocalDate.now()}"  // ex) ranking:order:2025-09-12
+
+        val typedTuples = entries.map { (productId, score) ->
+            ZSetOperations.TypedTuple.of(productId, score)
+        }.toSet()
+
+        redisTemplate.opsForZSet().add("ranking:order", typedTuples)
+    }
+
+    private fun saveRanking() {
+        // TODO
+    }
+}

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/dto/OrderCompletedItem.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/dto/OrderCompletedItem.kt
@@ -1,4 +1,4 @@
-package com.loopers.domain.order
+package com.loopers.domain.order.dto
 
 data class OrderCompletedItem(
     val productId: Long,

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/dto/OrderCompletedMessage.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/dto/OrderCompletedMessage.kt
@@ -1,4 +1,4 @@
-package com.loopers.domain.order
+package com.loopers.domain.order.dto
 
 data class OrderCompletedMessage(
     val orderId: Long,

--- a/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/dto/OrderMessageEnvelope.kt
+++ b/apps/commerce-streamer/src/main/kotlin/com/loopers/domain/order/dto/OrderMessageEnvelope.kt
@@ -1,4 +1,4 @@
-package com.loopers.domain.order
+package com.loopers.domain.order.dto
 
 import com.fasterxml.jackson.databind.JsonNode
 


### PR DESCRIPTION
## 📌 Summary

이번주는 다른 일정이 조금 바빠서 진행을 못 했습니다 ㅠㅠ 주말에 따로 진행을 해볼 예정입니다...

## 💬 Review Points

## ✅ Checklist

### 📈 Ranking Consumer

- [ ]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [ ]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [ ]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [ ]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [ ]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [ ]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

## 📎 References